### PR TITLE
fpga: Tie off LC clock bypass signals to multibit false

### DIFF
--- a/fpga/src/backdoor_otp.sv
+++ b/fpga/src/backdoor_otp.sv
@@ -237,7 +237,7 @@ module backdoor_otp
         state_d = ReadWaitSt;
         req     = 1'b1;
         // Suppress ECC correction if needed.
-        read_ecc_on = integrity_en_q;
+        //read_ecc_on = integrity_en_q;
       end
       // Wait for response from macro.
       ReadWaitSt: begin
@@ -340,8 +340,9 @@ module backdoor_otp
     .data_i     (rdata_ecc),
     .data_o     (rdata_corr),
     .syndrome_o ( ),
-    .err_o      (rerror)
+    .err_o      ()
   );
+  assign rerror = 2'b00; // disable ECC errors
 
   assign rdata_d = (read_ecc_on) ? {{EccWidth{1'b0}}, rdata_corr}
                                  : rdata_ecc;
@@ -365,7 +366,8 @@ module backdoor_otp
   assign mem_en = req;
   assign mem_we = wren && req;
   assign mem_wdata = wdata_rmw & 16'hffff; // Mask out ECC bits for the input
-  assign mem_rdata = rdata_ecc & 16'hffff; // Mask out ECC bits for the output
+  //assign mem_rdata = rdata_ecc & 16'hffff; // Mask out ECC bits for the output
+  assign rdata_ecc = mem_rdata;
   assign mem_addr = addr;
   assign rvalid = 1'b1;
 

--- a/fpga/src/caliptra_wrapper_top.sv
+++ b/fpga/src/caliptra_wrapper_top.sv
@@ -2113,9 +2113,9 @@ caliptra_ss_top caliptra_ss_top_0 (
     /*output logic        */ .cptra_ss_dbg_manuf_enable_o(),
     /*output logic [63:0] */ .cptra_ss_cptra_core_soc_prod_dbg_unlock_level_o(),
 
-    // LC Clock bypass not interesting for FPGA. Disconnect
-    .cptra_ss_lc_clk_byp_ack_i(),
-    .cptra_ss_lc_clk_byp_req_o(),
+    // LC Clock bypass not interesting for FPGA. Tie to Off so that LC transitions work.
+    .cptra_ss_lc_clk_byp_ack_i(lc_ctrl_pkg::Off),
+    .cptra_ss_lc_clk_byp_req_o(lc_ctrl_pkg::Off),
     .cptra_ss_lc_ctrl_scan_rst_ni_i(1'b1),
 
     .cptra_ss_lc_esclate_scrap_state0_i(hwif_out.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value),   // NOTE: These two signals are very important. FIXME: Renaming is needed


### PR DESCRIPTION
The LC clock bypass signals have to be set to the same multibit true or false value or the LC will always report an error.

And calculate OTP ECC and never return errors.

We don't use ECC for our OTP SRAM, so we can just calculate the ECC bits and pretend that it always works.

With these changes, the OTP and LC controllers work well enough to do LC transitions and provision data.

There is still a bug where the OTP controller will throw errors if integrity checking is enabled, but I haven't figured that out yet.